### PR TITLE
removing `pull_request` from recommended triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 ## How to use jupydiff
 **jupydiff** is a GitHub action. This means it can be used in any GitHub repostitory (public or private) by configuring a [GitHub Action workflow](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions) in your repository.
 
-See below for an example workflow that runs **jupydiff** on any commit or pull request made to the repository.
+See below for an example workflow that runs **jupydiff** on any commit made to the repository. Comments on commits will be automatically added to relevant pull requests.
 
 ```yaml
 name: jupydiff
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
   build:


### PR DESCRIPTION
Jupydiff leaves a few too many comments since PRs automatically include relevant commit comments